### PR TITLE
Use atdgen to generate JSON bindings for OCaml

### DIFF
--- a/ocaml/ast.ml
+++ b/ocaml/ast.ml
@@ -171,7 +171,10 @@ and redirs (n : node union ptr) =
       let vname = getf n ndup_vname in
       let tgt =
         if nullptr vname
-        then List.map (fun c -> C c) (explode (string_of_int (getf n ndup_dupfd)))
+        then let dupfd = getf n ndup_dupfd in
+             if dupfd = -1
+             then [C '-']
+             else List.map (fun c -> C c) (explode (string_of_int dupfd))
         else to_arg (vname @-> node_narg)
       in
       Dup (ty,getf n ndup_fd,tgt) in

--- a/ocaml/ast.ml
+++ b/ocaml/ast.ml
@@ -1,51 +1,98 @@
 type linno = int
 
-type t =
-  | Command of linno * assign list * args * redirection list (* assign, args, redir *)
-  | Pipe of bool * t list (* background?, commands *)
-  | Redir of linno * t * redirection list
-  | Background of linno * t * redirection list 
-  | Subshell of linno * t * redirection list
-  | And of t * t
-  | Or of t * t
-  | Not of t
-  | Semi of t * t
-  | If of t * t * t (* cond, then, else *)
-  | While of t * t (* test, body *) (* until encoded as a While . Not *)
-  | For of linno * arg * t * string (* args, body, var *)
-  | Case of linno * arg * case list
-  | Defun of linno * string * t (* name, body *)
- and assign = string * arg
- and redirection =
-   | File of redir_type * int * arg
-   | Dup of dup_type * int * arg
-   | Heredoc of heredoc_type * int * arg
- and redir_type = To | Clobber | From | FromTo | Append
- and dup_type = ToFD | FromFD
- and heredoc_type = Here | XHere (* for when in a quote... not sure when this comes up *)
- and args = arg list
- and arg = arg_char list
- and arg_char =
-   | C of char
-   | E of char (* escape... necessary for expansion *)
-   | T of string option (* tilde *)
-   | A of arg (* arith *)
-   | V of var_type * bool (* VSNUL? *) * string * arg
-   | Q of arg (* quoted *)
-   | B of t (* backquote *)
- and var_type =
-   | Normal
-   | Minus
-   | Plus
-   | Question
-   | Assign
-   | TrimR
-   | TrimRMax
-   | TrimL
-   | TrimLMax
-   | Length
- and case = { cpattern : arg list; cbody : t }
+(* type t =
+ *   | Command of linno * assign list * args * redirection list (\* assign, args, redir *\)
+ *   | Pipe of bool * t list (\* background?, commands *\)
+ *   | Redir of linno * t * redirection list
+ *   | Background of linno * t * redirection list 
+ *   | Subshell of linno * t * redirection list
+ *   | And of t * t
+ *   | Or of t * t
+ *   | Not of t
+ *   | Semi of t * t
+ *   | If of t * t * t (\* cond, then, else *\)
+ *   | While of t * t (\* test, body *\) (\* until encoded as a While . Not *\)
+ *   | For of linno * arg * t * string (\* args, body, var *\)
+ *   | Case of linno * arg * case list
+ *   | Defun of linno * string * t (\* name, body *\)
+ *  and assign = string * arg
+ *  and redirection =
+ *    | File of redir_type * int * arg
+ *    | Dup of dup_type * int * arg
+ *    | Heredoc of heredoc_type * int * arg
+ *  and redir_type = To | Clobber | From | FromTo | Append
+ *  and dup_type = ToFD | FromFD
+ *  and heredoc_type = Here | XHere (\* for when in a quote... not sure when this comes up *\)
+ *  and args = arg list
+ *  and arg = arg_char list
+ *  and arg_char =
+ *    | C of char
+ *    | E of char (\* escape... necessary for expansion *\)
+ *    | T of string option (\* tilde *\)
+ *    | A of arg (\* arith *\)
+ *    | V of var_type * bool (\* VSNUL? *\) * string * arg
+ *    | Q of arg (\* quoted *\)
+ *    | B of t (\* backquote *\)
+ *  and var_type =
+ *    | Normal
+ *    | Minus
+ *    | Plus
+ *    | Question
+ *    | Assign
+ *    | TrimR
+ *    | TrimRMax
+ *    | TrimL
+ *    | TrimLMax
+ *    | Length
+ *  and case = { cpattern : arg list; cbody : t } *)
 
+type t =
+    Command of (linno * assign list * args * redirection list)
+  | Pipe of (bool * t list)
+  | Redir of (linno * t * redirection list)
+  | Background of (linno * t * redirection list)
+  | Subshell of (linno * t * redirection list)
+  | And of (t * t)
+  | Or of (t * t)
+  | Not of t
+  | Semi of (t * t)
+  | If of (t * t * t)
+  | While of (t * t)
+  | For of (linno * arg * t * string)
+  | Case of (linno * arg * case list)
+  | Defun of (linno * string * t)
+and assign = (string * arg)
+and redirection =
+    File of (redir_type * int * arg)
+  | Dup of (dup_type * int * arg)
+  | Heredoc of (heredoc_type * int * arg)
+and redir_type = To | Clobber | From | FromTo | Append
+and dup_type = ToFD | FromFD
+and heredoc_type = Here | XHere
+and args = arg list
+and arg = arg_char list
+and arg_char =
+    C of char
+  | E of char
+  | T of string option
+  | A of arg
+  | V of (var_type * bool * string * arg)
+  | Q of arg
+  | B of t
+and var_type =
+    Normal
+  | Minus
+  | Plus
+  | Question
+  | Assign
+  | TrimR
+  | TrimRMax
+  | TrimL
+  | TrimLMax
+  | Length
+and case = { cpattern : arg list; cbody : t; }
+
+              
 let var_type = function
  | 0x0 -> (* VSNORMAL ${var} *) Normal
  | 0x2 -> (* VSMINUS ${var-text} *) Minus

--- a/ocaml/ast.mli
+++ b/ocaml/ast.mli
@@ -1,25 +1,25 @@
 type linno = int
 
 type t =
-    Command of linno * assign list * args * redirection list
-  | Pipe of bool * t list
-  | Redir of linno * t * redirection list
-  | Background of linno * t * redirection list
-  | Subshell of linno * t * redirection list
-  | And of t * t
-  | Or of t * t
+    Command of (linno * assign list * args * redirection list)
+  | Pipe of (bool * t list)
+  | Redir of (linno * t * redirection list)
+  | Background of (linno * t * redirection list)
+  | Subshell of (linno * t * redirection list)
+  | And of (t * t)
+  | Or of (t * t)
   | Not of t
-  | Semi of t * t
-  | If of t * t * t
-  | While of t * t
-  | For of linno * arg * t * string
-  | Case of linno * arg * case list
-  | Defun of linno * string * t
-and assign = string * arg
+  | Semi of (t * t)
+  | If of (t * t * t)
+  | While of (t * t)
+  | For of (linno * arg * t * string)
+  | Case of (linno * arg * case list)
+  | Defun of (linno * string * t)
+and assign = (string * arg)
 and redirection =
-    File of redir_type * int * arg
-  | Dup of dup_type * int * arg
-  | Heredoc of heredoc_type * int * arg
+    File of (redir_type * int * arg)
+  | Dup of (dup_type * int * arg)
+  | Heredoc of (heredoc_type * int * arg)
 and redir_type = To | Clobber | From | FromTo | Append
 and dup_type = ToFD | FromFD
 and heredoc_type = Here | XHere
@@ -30,7 +30,7 @@ and arg_char =
   | E of char
   | T of string option
   | A of arg
-  | V of var_type * bool * string * arg
+  | V of (var_type * bool * string * arg)
   | Q of arg
   | B of t
 and var_type =


### PR DESCRIPTION
This will help us keep the OCaml bindings in line with the Python bindings, reusing existing tests from pash.